### PR TITLE
fix: Namespace dependency

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,12 +1,3 @@
-resource "kubernetes_namespace" "alb_ingress" {
-  depends_on = [var.mod_dependency]
-  count      = (var.enabled && var.k8s_namespace != "kube-system") ? 1 : 0
-
-  metadata {
-    name = var.k8s_namespace
-  }
-}
-
 ### iam ###
 # Policy
 data "http" "alb_ingress_policy" {

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,12 @@
 resource "helm_release" "alb_ingress" {
-  depends_on = [var.mod_dependency]
-  count      = var.enabled ? 1 : 0
-  name       = var.helm_release_name
-  repository = var.helm_repo_url
-  chart      = var.helm_chart_name
-  namespace  = var.k8s_namespace
-  version    = var.helm_chart_version
+  depends_on       = [var.mod_dependency]
+  count            = var.enabled ? 1 : 0
+  name             = var.helm_release_name
+  repository       = var.helm_repo_url
+  chart            = var.helm_chart_name
+  create_namespace = var.k8s_namespace != "kube-system" ? true : false
+  namespace        = var.k8s_namespace
+  version          = var.helm_chart_version
 
   set {
     name  = "clusterName"


### PR DESCRIPTION
Fix the namespace dependency , now it errors when removing the module cause the namespace is deleted before the helm release.
Also the whole resource is not needed as helm release can create a namespace